### PR TITLE
Fixed some test cases and slightly refined the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,7 @@ tracing-active-tree = { git = "https://github.com/tikv/tracing-active-tree.git",
     }
 
     fn debug_dump_current_tree() -> String {
-        let layer =
-            dispatcher::get_default(|d| d.downcast_ref::<CurrentStacksLayer>().unwrap().clone());
-        layer.fmt_string()
+        layer::global().fmt_string()
     }
     ```
 
@@ -88,10 +86,10 @@ tracing-active-tree = { git = "https://github.com/tikv/tracing-active-tree.git",
     ```sh
     1
     └[examples/simple.rs:5] [span_id=1] ["foo"] [answer=43] [elapsed=114.659µs]
-    └[examples/simple.rs:10] [span_id=2] ["bar"] [elapsed=92.5µs]
-    ├[examples/simple.rs:15] [span_id=3] ["fiz"] [elapsed=79.072µs]
-    └[examples/simple.rs:20] [span_id=4] ["buz"] [elapsed=65.938µs]
-    └[examples/simple.rs:25] [span_id=5] ["baz"] [elapsed=59.61µs]
+     └[examples/simple.rs:10] [span_id=2] ["bar"] [elapsed=92.5µs]
+      ├[examples/simple.rs:15] [span_id=3] ["fiz"] [elapsed=79.072µs]
+      └[examples/simple.rs:20] [span_id=4] ["buz"] [elapsed=65.938µs]
+       └[examples/simple.rs:25] [span_id=5] ["baz"] [elapsed=59.61µs]
     ```
 
 ## Benchmark

--- a/examples/complex_call.rs
+++ b/examples/complex_call.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use futures_util::future::BoxFuture;
 use tracing::instrument;
-use tracing_active_tree::{frame, layer, tree::formating::FormatFlat};
+use tracing_active_tree::{frame, layer};
 use tracing_subscriber::prelude::*;
 
 /*

--- a/examples/complex_call.rs
+++ b/examples/complex_call.rs
@@ -55,14 +55,7 @@ async fn quux(n: usize) {
     // Give the newly spawned task a chance to be scheduled.
     tokio::task::yield_now().await;
     let print = async {
-        println!(
-            "{}",
-            String::from_utf8(
-                layer::global()
-                    .fmt_bytes_with(|tree, buf| tree.traverse_with(FormatFlat::new(buf)).unwrap())
-            )
-            .unwrap()
-        );
+        println!("{}", layer::global().fmt_string());
     };
     futures::future::join_all(tasks.chain(std::iter::once(Box::pin(print) as BoxFuture<_>))).await;
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,7 +1,7 @@
 // Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
 
-use tracing::{dispatcher, instrument};
-use tracing_active_tree::layer::{self, CurrentStacksLayer};
+use tracing::instrument;
+use tracing_active_tree::layer;
 use tracing_subscriber::prelude::*;
 
 #[instrument(fields(answer = 43))]
@@ -30,9 +30,7 @@ async fn baz() {
 }
 
 fn debug_dump_current_tree() -> String {
-    let layer =
-        dispatcher::get_default(|d| d.downcast_ref::<CurrentStacksLayer>().unwrap().clone());
-    layer.fmt_string()
+    layer::global().fmt_string()
 }
 
 #[tokio::main(flavor = "current_thread")]

--- a/src/test.rs
+++ b/src/test.rs
@@ -107,7 +107,7 @@ async fn exec() {
             "<step_out>",
             "<step_out>",
             "<step_out>",
-            "<step_out>",
+            "<step_out>"
         ]
     );
     assert_eq!(tree["pending"], ["pending", "<step_out>"]);
@@ -159,7 +159,6 @@ async fn buz(tx: oneshot::Sender<HashMap<String, Vec<String>>>) {
 
 #[instrument(skip_all)]
 async fn baz(tx: oneshot::Sender<HashMap<String, Vec<String>>>) {
-    println!("{}", debug_dump_current_tree());
     let _ = tx.send(collect_tree());
 }
 
@@ -191,7 +190,6 @@ async fn join_many(max: usize) -> HashMap<String, Vec<String>> {
     let (tx, rx) = oneshot::channel();
     tokio::spawn(async move {
         tokio::task::yield_now().await;
-        println!("{}", debug_dump_current_tree());
         tx.send(collect_tree()).unwrap();
         drop(v);
     });
@@ -220,9 +218,20 @@ async fn test_long_stack() {
     let (tx, rx) = oneshot::channel();
     let jh = tokio::spawn(root!(count_to_zero(20, rx)));
     tokio::task::yield_now().await;
-    println!("{}", debug_dump_current_tree());
+    let tree = collect_tree();
     tx.send(()).unwrap();
     jh.await.unwrap();
+    assert_eq!(
+        tree["count_to_zero(20, rx)"],
+        ["count_to_zero(20, rx)"]
+            .iter()
+            .copied()
+            .chain(std::iter::repeat("count_to_zero(n - 1, rx)").take(20))
+            // One extra <step_out> for the root frame.
+            .chain(std::iter::repeat("<step_out>").take(21))
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(tree.len(), 1);
 }
 
 #[tokio::test]

--- a/src/test.rs
+++ b/src/test.rs
@@ -107,7 +107,7 @@ async fn exec() {
             "<step_out>",
             "<step_out>",
             "<step_out>",
-            "<step_out>"
+            "<step_out>",
         ]
     );
     assert_eq!(tree["pending"], ["pending", "<step_out>"]);


### PR DESCRIPTION
This PR fixed some inconsistent of the codebase:
- Fixed the test case without checking `test_long_stack`.
- Removed the debug call in test cases.
- Fixed the indent of `README.md`.
- Call the global layer directly in `README.md`, in fact there is a glitch that calls like `dispatcher::get_default(|d| d.downcast_ref::<CurrentStacksLayer>().unwrap().fmt_string())` will return many false deleted spans(`dispatcher::get_default` returns `NopDispatcher` in nested calls! perhaps we need to clarify that in a more observable space?).
